### PR TITLE
Fix memory leak from transactions due to players not always respondin…

### DIFF
--- a/src/main/java/ac/boar/anticheat/config/Config.java
+++ b/src/main/java/ac/boar/anticheat/config/Config.java
@@ -37,6 +37,9 @@ public final class Config {
     @JsonProperty("max-acknowledgement-time")
     @JsonSetter(nulls = Nulls.SKIP)
     private long maxAcknowledgementTime = 500;
+    @JsonProperty("latency-compensation-timeout")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private long latencyCompensationTimeout = 30_000;
     @JsonProperty("max-balance-advantage")
     @JsonSetter(nulls = Nulls.SKIP)
     private long maxBalanceAdvantage = 2000L;

--- a/src/main/java/ac/boar/anticheat/player/BoarPlayer.java
+++ b/src/main/java/ac/boar/anticheat/player/BoarPlayer.java
@@ -123,7 +123,10 @@ public final class BoarPlayer extends PlayerData {
         latencyPacket.setTimestamp(-id);
         latencyPacket.setFromServer(true);
 
-        this.latencyUtil.addLatencyToQueue(id);
+        if (!this.latencyUtil.addLatencyToQueue(id)) {
+            kick("Failed to respond to transactions for too long");
+            return;
+        }
 
         if (immediate) {
             this.getSession().sendUpstreamPacketImmediately(latencyPacket);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -49,5 +49,10 @@ max-acknowledgement-time: -1
 # To disable (which you probably shouldn't), set this to any value smaller or equals to 0.
 max-balance-advantage: 8500
 
+# How much in milliseconds should we wait for a response to transactions before disconnecting the user
+# This can't be too low because bedrock clients often take their time to answer when loading the world, but it also can't be too high because
+# custom clients can often avoid responding to transactions which end up creating a memory leak
+latency-compensation-timeout: 30000
+
 # Should debug mode be enabled or not?
 debug-mode: false


### PR DESCRIPTION
…g to transactions - either because they are just lagging - or because they are using custom clients
I've noticed this happening a lot on DonutSMP. We would crash after some time and after debugging it, there are players who are not answering to transactions pretty much never.