### PR TITLE
Add configurable message prefixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
 
     compileOnly("com.google.code.gson:gson:2.3.1")
     testImplementation("com.google.code.gson:gson:2.3.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.14.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.14.4")
 
     implementation("it.unimi.dsi:fastutil:8.5.15")
 
@@ -32,6 +34,10 @@ dependencies {
 }
 
 tasks {
+    test {
+        useJUnitPlatform()
+    }
+
     shadowJar {
         archiveFileName = "boar.jar"
 

--- a/src/main/java/ac/boar/anticheat/alert/AlertManager.java
+++ b/src/main/java/ac/boar/anticheat/alert/AlertManager.java
@@ -1,5 +1,6 @@
 package ac.boar.anticheat.alert;
 
+import ac.boar.anticheat.Boar;
 import org.geysermc.geyser.api.command.CommandSource;
 
 import java.util.*;
@@ -7,9 +8,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class AlertManager {
     public final static UUID CONSOLE_UUID = new UUID(0, 0);
-
-    private final static String PREFIX = "§3Boar §7>§r ";
-    private final static String BEDROCK_PREFIX = "§sBoar §i>§r ";
 
     private final Map<UUID, CommandSource> sources = new ConcurrentHashMap<>();
 
@@ -23,10 +21,10 @@ public class AlertManager {
 
     public String getPrefix(CommandSource source) {
         if (source.connection() != null) {
-            return BEDROCK_PREFIX;
+            return Boar.getConfig().bedrockPrefix();
         }
 
-        return PREFIX;
+        return Boar.getConfig().prefix();
     }
 
     public boolean hasAlert(CommandSource source) {

--- a/src/main/java/ac/boar/anticheat/config/Config.java
+++ b/src/main/java/ac/boar/anticheat/config/Config.java
@@ -40,6 +40,12 @@ public final class Config {
     @JsonProperty("debug-mode")
     @JsonSetter(nulls = Nulls.SKIP)
     private boolean debugMode;
+    @JsonProperty("prefix")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private String prefix = "§3Boar §7>§r ";
+    @JsonProperty("bedrock-prefix")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private String bedrockPrefix = "§sBoar §i>§r ";
 
     public int rewindHistory() {
         return rewindHistory;
@@ -75,5 +81,17 @@ public final class Config {
 
     public boolean debugMode() {
         return debugMode;
+    }
+
+    public String prefix() {
+        return formatPrefix(prefix);
+    }
+
+    public String bedrockPrefix() {
+        return formatPrefix(bedrockPrefix);
+    }
+
+    private String formatPrefix(String prefix) {
+        return prefix.replace('&', '§');
     }
 }

--- a/src/main/java/ac/boar/anticheat/config/ConfigLoader.java
+++ b/src/main/java/ac/boar/anticheat/config/ConfigLoader.java
@@ -69,6 +69,8 @@ public class ConfigLoader {
                         s = s.replace("differ-till-alert: 0.0", "differ-till-alert: " + config.alertThreshold());
                         s = s.replace("debug-mode: false", "debug-mode: " + config.debugMode());
                         s = s.replace("max-latency-wait: 15000", "max-latency-wait: " + config.maxLatencyWait());
+                        s = s.replace("prefix: \"&3Boar &7>&r \"", "prefix: \"" + config.prefix() + "\"");
+                        s = s.replace("bedrock-prefix: \"&sBoar &i>&r \"", "bedrock-prefix: \"" + config.bedrockPrefix() + "\"");
                     }
 
                     writer.write(s.toCharArray());

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,8 @@
 # This contains the anti-cheat related configurations.
 
+prefix: "&3Boar &7>&r "
+bedrock-prefix: "&sBoar &i>&r "
+
 # How many ticks of history are contained in the client's rolling window for use when receiving corrections.
 # At 20 ticks per second a history size of 40 means that a correction could still be processed with rewind with
 # two seconds of two-way latency

--- a/src/test/java/ac/boar/anticheat/config/ConfigTest.java
+++ b/src/test/java/ac/boar/anticheat/config/ConfigTest.java
@@ -1,0 +1,32 @@
+package ac.boar.anticheat.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigTest {
+    private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .disable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES)
+            .disable(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES);
+
+    @Test
+    void usesDefaultPrefix() {
+        assertEquals("§3Boar §7>§r ", Config.DEFAULT_CONFIG.prefix());
+        assertEquals("§sBoar §i>§r ", Config.DEFAULT_CONFIG.bedrockPrefix());
+    }
+
+    @Test
+    void loadsConfiguredPrefix() throws Exception {
+        Config config = mapper.readValue("""
+                prefix: '&6Boar &8> &r'
+                bedrock-prefix: '&eBoar &7> &r'
+                """, Config.class);
+
+        assertEquals("§6Boar §8> §r", config.prefix());
+        assertEquals("§eBoar §7> §r", config.bedrockPrefix());
+    }
+}


### PR DESCRIPTION
Adds configurable prefixes for Boar messages.

Changed:
- added prefix and edrock-prefix config options
- kept the current Java and Bedrock defaults
- accepts & color codes in configured prefixes
- added a small config test

Tested:
- ./gradlew.bat test
- ./gradlew.bat build

Closes #48