### PR TITLE
Fix several movement, collision and item-mapping bugs

### DIFF
--- a/common/src/main/java/ac/boar/anticheat/check/impl/prediction/Prediction.java
+++ b/common/src/main/java/ac/boar/anticheat/check/impl/prediction/Prediction.java
@@ -80,7 +80,7 @@ public class Prediction extends BaseCheck implements OffsetHandlerCheck {
     }
 
     public boolean shouldDoFail() {
-        return player.tickSinceBlockResync <= 0 && !player.insideUnloadedChunk && !player.getTeleportUtil().isTeleporting() && player.sinceLoadingScreen > 5 && player.compensatedWorld.isChunkLoaded((int) player.position.x, (int) player.position.z);
+        return player.tickSinceBlockResync <= 0 && !player.insideUnloadedChunk && !player.getTeleportUtil().isTeleporting() && player.sinceLoadingScreen > 5 && player.compensatedWorld.isChunkLoadedAt(player.position.x, player.position.z);
     }
 
     public void fail(String name, String verbose) {

--- a/common/src/main/java/ac/boar/anticheat/compensated/world/base/CompensatedWorld.java
+++ b/common/src/main/java/ac/boar/anticheat/compensated/world/base/CompensatedWorld.java
@@ -18,6 +18,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.cloudburstmc.math.GenericMath;
 import org.cloudburstmc.math.vector.Vector3i;
 
 import java.util.ArrayList;
@@ -78,7 +79,7 @@ public class CompensatedWorld {
         });
     }
 
-    public boolean isOutOfRadius(int chunkX, int chunkZ) {
+    public boolean isOutOfRadius(int blockX, int blockZ) {
         if (this.radiusCenter == null || this.radius <= 0) {
             return false;
         }
@@ -87,7 +88,7 @@ public class CompensatedWorld {
 
         // Still unsure about this... should we get rid of chunk sections, or chunk?
         // Well since we're getting rid of chunks for now, let set the y pos to 0.
-        Vec3 chunkCenter = new Vec3(chunkX + 8, 0, chunkZ + 8);
+        Vec3 chunkCenter = new Vec3(blockX + 8, 0, blockZ + 8);
         return radiusCenter.squaredDistanceTo(chunkCenter) > this.radius * this.radius && new Vec3(player.position.x, 0, player.position.z).squaredDistanceTo(chunkCenter) > this.radius * this.radius;
     }
 
@@ -117,8 +118,16 @@ public class CompensatedWorld {
         this.chunks.remove(MathUtil.chunkPositionToLong(x, z));
     }
 
-    public boolean isChunkLoaded(int chunkX, int chunkZ) {
-        return this.getChunk(chunkX >> 4, chunkZ >> 4) != null;
+    public boolean isChunkLoaded(int blockX, int blockZ) {
+        return this.getChunk(blockX >> 4, blockZ >> 4) != null;
+    }
+
+    // Resolve the loaded-chunk lookup from a player/entity position. A plain (int) cast rounds towards
+    // zero instead of flooring, so at negative coordinates it resolves to the neighbouring chunk in the
+    // one-block strip next to every chunk border (x or z in -1..0, -17..-16, ...) - prediction could then
+    // run against a not-yet-loaded chunk and rewind the player. Floor, matching Geyser and vanilla.
+    public boolean isChunkLoadedAt(float x, float z) {
+        return this.isChunkLoaded(GenericMath.floor(x), GenericMath.floor(z));
     }
 
     public void updateBlock(final Vector3i position, int layer, int block) {

--- a/common/src/main/java/ac/boar/anticheat/packets/input/AuthInputPackets.java
+++ b/common/src/main/java/ac/boar/anticheat/packets/input/AuthInputPackets.java
@@ -64,7 +64,10 @@ public class AuthInputPackets extends TeleportHandler implements PacketListener 
         LegacyAuthInputPackets.processAuthInput(player, packet, true);
         LegacyAuthInputPackets.updateUnvalidatedPosition(player, packet);
 
-        ((Reach) player.getCheckHolder().get(Reach.class)).pollQueuedHits();
+        final Reach reach = (Reach) player.getCheckHolder().get(Reach.class);
+        if (reach != null) { // null when the Reach check is disabled via disabled-checks - don't NPE.
+            reach.pollQueuedHits();
+        }
 
         player.tick();
 

--- a/common/src/main/java/ac/boar/anticheat/packets/input/AuthInputPackets.java
+++ b/common/src/main/java/ac/boar/anticheat/packets/input/AuthInputPackets.java
@@ -91,7 +91,7 @@ public class AuthInputPackets extends TeleportHandler implements PacketListener 
             }
         }
 
-        player.insideUnloadedChunk = !player.compensatedWorld.isChunkLoaded((int) player.position.x, (int) player.position.z);
+        player.insideUnloadedChunk = !player.compensatedWorld.isChunkLoadedAt(player.position.x, player.position.z);
         // Don't try to predict player position in an unloaded chunk, it's not worth it and uh won't go well!
         // Just keep teleporting the player back until they loaded in, that way we shouldn't false post teleport... I think!
         // There isn't much room to abuse considering they're not loaded in any way... and the position is validated so

--- a/common/src/main/java/ac/boar/anticheat/prediction/PredictionRunner.java
+++ b/common/src/main/java/ac/boar/anticheat/prediction/PredictionRunner.java
@@ -36,8 +36,8 @@ public class PredictionRunner {
             Boar.debug("[velocity-debug] predict tick=" + player.tick + " velocity=" + player.bestPossibility.getVelocity() + " actualDelta=" + player.unvalidatedTickEnd + " pos=" + player.position + " unvalidated=" + player.unvalidatedPosition, Boar.DebugMessage.INFO);
         }
 
-        // We can start the ACTUAL prediction now.
-        player.velocity = player.bestPossibility.getVelocity();
+        // We can store the ACTUAL prediction now.
+        player.velocity = player.bestPossibility.getVelocity().clone();
         return true;
     }
 }

--- a/common/src/main/java/ac/boar/anticheat/prediction/ticker/base/EntityTicker.java
+++ b/common/src/main/java/ac/boar/anticheat/prediction/ticker/base/EntityTicker.java
@@ -202,7 +202,7 @@ public class EntityTicker {
         }
 
         if (zCollision) {
-            movementAfterBounce.z = currentMovement.z * restitution;
+            movementAfterBounce.z = -currentMovement.z * restitution;
         }
 
         if (player.verticalCollision) {

--- a/common/src/main/java/ac/boar/anticheat/util/math/Vec3.java
+++ b/common/src/main/java/ac/boar/anticheat/util/math/Vec3.java
@@ -127,7 +127,7 @@ public class Vec3 implements Cloneable {
     }
 
     public Vec3 divide(float v, float v1, float v2) {
-        return new Vec3(this.x * v, this.y * v1, this.z * v2);
+        return new Vec3(this.x / v, this.y / v1, this.z / v2);
     }
 
     public Vec3 up(float v) {

--- a/common/src/main/java/ac/boar/mappings/item/Items.java
+++ b/common/src/main/java/ac/boar/mappings/item/Items.java
@@ -11,7 +11,7 @@ public final class Items {
     public static final Reference<Item> BUCKET = create("bucket");
     public static final Reference<Item> CROSSBOW = create("crossbow");
     public static final Reference<Item> DIAMOND_SPEAR = create("diamond_spear");
-    public static final Reference<Item> ELYTRA = create("elyra");
+    public static final Reference<Item> ELYTRA = create("elytra");
     public static final Reference<Item> ENDER_EYE = create("ender_eye");
     public static final Reference<Item> FIRE_CHARGE = create("fire_charge");
     public static final Reference<Item> FIREWORK_ROCKET = create("firework_rocket");
@@ -19,7 +19,7 @@ public final class Items {
     public static final Reference<Item> GLOWSTONE = create("glowstone");
     public static final Reference<Item> GOLDEN_SPEAR = create("golden_spear");
     public static final Reference<Item> IRON_SPEAR = create("iron_spear");
-    public static final Reference<Item> LAVA_BUCKET = create("water_bucket");
+    public static final Reference<Item> LAVA_BUCKET = create("lava_bucket");
     public static final Reference<Item> LEATHER_BOOTS = create("leather_boots");
     public static final Reference<Item> NETHERITE_SPEAR = create("netherite_spear");
     public static final Reference<Item> OMINOUS_BOTTLE = create("ominous_bottle");


### PR DESCRIPTION
This PR collects a set of independent bug fixes found while running Boar on a live Bedrock server.

### Fixes

- **Elytra / lava bucket item id typos** — `ELYTRA` was mapped to the identifier `elyra`, so `is(ELYTRA)` never matched a real elytra and the `GLIDING` flag was never set; a gliding player was predicted as free-falling and set back. `LAVA_BUCKET` was mapped to `water_bucket`.
- **`Vec3#divide` multiplied instead of dividing** — each component was multiplied by the divisor rather than divided by it.
- **Z restitution sign** — the Z branch of `restituteMovementAfterCollisions` kept the original sign while the X branch negates it, so a Z-axis bounce reflected the wrong way.
- **Chunk-border position rounding** — position-based loaded-chunk lookups cast the player position with `(int)`, which rounds towards zero instead of flooring. At negative coordinates that resolves to the neighbouring chunk in the one-block strip next to every chunk border, so prediction could run against a not-yet-loaded chunk and rewind the player. Added `isChunkLoadedAt(float, float)` that floors (matching Geyser and vanilla).
- **Velocity snapshot aliasing** — the tick-start velocity was assigned by reference, so the ticker mutating `player.velocity` in place also corrupted `bestPossibility`, whose untouched value the knockback comparison relies on. Clone it.
- **NPE when Reach is disabled** — `CheckHolder` does not store a check listed in `disabled-checks`, so `getCheckHolder().get(Reach.class)` returns null when Reach is disabled; the auth-input handler cast and called it unconditionally, throwing an NPE every tick for every player. Null-checked, matching the existing pattern in `CheckHolder#manuallyFail`.