### PR TITLE
Fix facing/chest_type block property always resolving to null

### DIFF
--- a/geyser/src/main/java/ac/boar/geyser/anticheat/data/block/GeyserBoarBlockStateDelegate.java
+++ b/geyser/src/main/java/ac/boar/geyser/anticheat/data/block/GeyserBoarBlockStateDelegate.java
@@ -69,8 +69,9 @@ public class GeyserBoarBlockStateDelegate implements BoarBlockStateDelegate {
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public <T extends Comparable<T>> BoarBlockState with(Property<T> property, T value) {
-        BlockState newState = this.state.withValue(((GeyserProperty<T>) property).handle(), value);
+        BlockState newState = this.state.withValue((org.geysermc.geyser.level.block.property.Property) ((GeyserProperty<T>) property).handle(), value);
         return BoarBlockState.create(newState.javaId(), this.position, this.layer);
     }
 
@@ -85,8 +86,14 @@ public class GeyserBoarBlockStateDelegate implements BoarBlockStateDelegate {
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public <T extends Comparable<T>> T get(Property<T> property) {
-        return this.state.getValue(((GeyserProperty<T>) property).handle());
+        GeyserProperty<T> geyserProperty = (GeyserProperty<T>) property;
+        Object raw = this.state.getValue((org.geysermc.geyser.level.block.property.Property) geyserProperty.handle());
+        if (raw == null) {
+            return null;
+        }
+        return geyserProperty.converter() != null ? geyserProperty.converter().apply(raw) : (T) raw;
     }
 
     @Override

--- a/geyser/src/main/java/ac/boar/geyser/mappings/block/GeyserProperty.java
+++ b/geyser/src/main/java/ac/boar/geyser/mappings/block/GeyserProperty.java
@@ -2,5 +2,19 @@ package ac.boar.geyser.mappings.block;
 
 import ac.boar.mappings.block.Property;
 
-public record GeyserProperty<T extends Comparable<T>>(org.geysermc.geyser.level.block.property.Property<T> handle) implements Property<T> {
+import java.util.function.Function;
+
+/**
+ * Wraps a real Geyser {@link org.geysermc.geyser.level.block.property.Property} singleton. The handle MUST be the
+ * registry singleton, because Geyser's {@code BlockState#get} matches properties by instance identity ({@code ==});
+ * wrapping it in a fresh anonymous Property makes every lookup return null. When Boar's value type differs from
+ * Geyser's (Direction, ChestType), {@code converter} translates the raw Geyser value on read.
+ */
+public record GeyserProperty<T extends Comparable<T>>(
+        org.geysermc.geyser.level.block.property.Property<?> handle,
+        Function<Object, T> converter) implements Property<T> {
+
+    public GeyserProperty(org.geysermc.geyser.level.block.property.Property<T> handle) {
+        this(handle, null);
+    }
 }

--- a/geyser/src/main/java/ac/boar/geyser/mappings/block/GeyserPropertyProvider.java
+++ b/geyser/src/main/java/ac/boar/geyser/mappings/block/GeyserPropertyProvider.java
@@ -5,31 +5,27 @@ import org.geysermc.geyser.level.block.property.ChestType;
 import org.geysermc.geyser.level.block.property.Properties;
 import org.geysermc.geyser.level.physics.Direction;
 
-import java.util.Optional;
-import java.util.function.Function;
-
 public class GeyserPropertyProvider implements PropertyProvider {
     private static final GeyserPropertyProvider INSTANCE = new GeyserPropertyProvider();
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T extends Comparable<T>> GeyserProperty<T> get(String key) {
         return switch (key) {
             case "age_3" -> new GeyserProperty(Properties.AGE_3);
             case "bell_attachment" -> new GeyserProperty(Properties.BELL_ATTACHMENT);
             case "bites" -> new GeyserProperty(Properties.BITES);
-            case "chest_type" -> enumProperty(
+            case "chest_type" -> new GeyserProperty<>(
                     Properties.CHEST_TYPE,
-                    (ac.boar.mappings.block.ChestType type) -> ChestType.VALUES[type.ordinal()],
-                    type -> ac.boar.mappings.block.ChestType.VALUES[type.ordinal()]
+                    raw -> (T) ac.boar.mappings.block.ChestType.VALUES[((ChestType) raw).ordinal()]
             );
             case "door_hinge" -> new GeyserProperty(Properties.DOOR_HINGE);
             case "drag" -> new GeyserProperty(Properties.DRAG);
             case "half" -> new GeyserProperty(Properties.HALF);
             case "has_book" -> new GeyserProperty(Properties.HAS_BOOK);
-            case "horizontal_facing" -> enumProperty(
+            case "horizontal_facing" -> new GeyserProperty<>(
                     Properties.HORIZONTAL_FACING,
-                    (ac.boar.anticheat.util.math.Direction d) -> Direction.VALUES[d.ordinal()],
-                    d -> ac.boar.anticheat.util.math.Direction.VALUES[d.ordinal()]
+                    raw -> (T) ac.boar.anticheat.util.math.Direction.VALUES[((Direction) raw).ordinal()]
             );
             case "level" -> new GeyserProperty(Properties.LEVEL);
             case "lit" -> new GeyserProperty(Properties.LIT);
@@ -38,32 +34,6 @@ public class GeyserPropertyProvider implements PropertyProvider {
             case "vault_state" -> new GeyserProperty(Properties.VAULT_STATE);
             default -> throw new IllegalArgumentException("Unknown property: " + key);
         };
-    }
-
-    @SuppressWarnings("rawtypes")
-    private static <F extends Comparable<F>, T extends Comparable<T>> GeyserProperty enumProperty(org.geysermc.geyser.level.block.property.Property<F> property, Function<T, F> from, Function<F, T> to) {
-        return new GeyserProperty<T>(new org.geysermc.geyser.level.block.property.Property<>(property.name()) {
-
-            @Override
-            public int valuesCount() {
-                return property.valuesCount();
-            }
-
-            @Override
-            public int indexOf(T value) {
-                return property.indexOf(from.apply(value));
-            }
-
-            @Override
-            public Optional<T> valueOf(String string) {
-                return property.valueOf(string).map(to);
-            }
-
-            @Override
-            public String toString() {
-                return from.toString();
-            }
-        });
     }
 
     public static GeyserPropertyProvider get() {


### PR DESCRIPTION
`GeyserPropertyProvider` wrapped `HORIZONTAL_FACING`/`CHEST_TYPE` in a new anonymous `Property`, but Geyser's `BlockState#get` matches by instance identity (`keys[i] == property`) — so the wrapper never matched and every lookup returned `null`.

Effect: `BedrockCollision` saw null facing for trapdoors/chests/doors/anvils. Open trapdoors always used one wall orientation → players got stuck in them.

Fix: keep the real Geyser singleton as the handle; move the Geyser→Boar enum translation into an optional converter applied on read. No geometry changed.