### PR TITLE
Fix collision shapes for bars, walls, and misc blocks

### DIFF
--- a/common/src/main/java/ac/boar/anticheat/collision/BedrockCollision.java
+++ b/common/src/main/java/ac/boar/anticheat/collision/BedrockCollision.java
@@ -8,7 +8,6 @@ import ac.boar.anticheat.util.math.Box;
 import ac.boar.anticheat.util.math.Direction;
 import ac.boar.mappings.block.BlockMappings;
 import ac.boar.mappings.block.Blocks;
-import ac.boar.mappings.block.ChestType;
 import ac.boar.mappings.block.Properties;
 import ac.boar.mappings.item.Items;
 import org.cloudburstmc.math.vector.Vector3i;
@@ -30,10 +29,6 @@ public class BedrockCollision {
 
     // Chest
     protected final static List<Box> SINGLE_CHEST_SHAPE = List.of(new Box(0.025F, 0, 0.025F, 0.975F, 0.95F, 0.975F));
-    protected final static List<Box> NORTH_CHEST_SHAPE = List.of(new Box(0.025F, 0, 0, 0.975F, 0.95F, 0.975F));
-    protected final static List<Box> SOUTH_CHEST_SHAPE = List.of(new Box(0.025F, 0, 0.025F, 0.975F, 0.95F, 1));
-    protected final static List<Box> WEST_CHEST_SHAPE = List.of(new Box(0, 0, 0.025F, 0.975F, 0.95F, 0.975F));
-    protected final static List<Box> EAST_CHEST_SHAPE = List.of(new Box(0.025F, 0, 0.025F, 1, 0.95F, 0.975F));
 
     // Scaffolding
     protected final static List<Box> SCAFFOLDING_NORMAL_SHAPE;
@@ -56,6 +51,7 @@ public class BedrockCollision {
     protected final static List<Box> DOOR_WEST_SHAPE = List.of(new Box(0, 0, 0, 0.1825F, 1, 1));
 
     protected final static List<Box> LANTERN_SHAPE = List.of(new Box(0.3125F, 0, 0.3125F, 0.6875F, 0.5F, 0.6875F));
+    protected final static List<Box> HANGING_LANTERN_SHAPE = List.of(new Box(0.3125F, 0.125F, 0.3125F, 0.6875F, 0.625F, 0.6875F));
 
     protected final static List<Box> ANVIL_X_SHAPE = List.of(new Box(0.0F, 0.0F, 0.125F, 1.0F, 1.0F, 0.875F));
     protected final static List<Box> ANVIL_OTHER_SHAPE = List.of(new Box(0.125F, 0.0F, 0.0F, 0.875F, 1.0F, 1.0F));
@@ -63,6 +59,8 @@ public class BedrockCollision {
     protected final static List<Box> FALLING_POWDER_SNOW_SNOW = List.of(new Box(0.0F, 0.0F, 0.0F, 0.0625F, 0.05625F, 0.0625F));
 
     protected final static List<Box> END_PORTAL_FRAME_SHAPE = List.of(new Box(0, 0, 0, 1, 0.8125F, 1));
+
+    protected final static List<Box> TURTLE_EGG_SHAPE = List.of(new Box(0.2F, 0, 0.2F, 0.8F, 0.45F, 0.8F));
 
     static {
         // Scaffolding
@@ -88,6 +86,18 @@ public class BedrockCollision {
         }
     }
     
+    public static List<Box> buildThinBarsShape(boolean north, boolean east, boolean south, boolean west) {
+        if (!north && !east && !south && !west) {
+            return List.of(new Box(0.4375F, 0, 0.4375F, 0.5625F, 1, 0.5625F));
+        }
+        List<Box> boxes = new ArrayList<>();
+        if (north) boxes.add(new Box(0.4375F, 0, 0,      0.5625F, 1, 0.5F));
+        if (south) boxes.add(new Box(0.4375F, 0, 0.5F,   0.5625F, 1, 1));
+        if (west)  boxes.add(new Box(0,       0, 0.4375F, 0.5F,   1, 0.5625F));
+        if (east)  boxes.add(new Box(0.5F,    0, 0.4375F, 1,      1, 0.5625F));
+        return boxes;
+    }
+
     public static List<Box> getCollisionBox(final BoarPlayer player, final Box box, final Vector3i vector3i, final BoarBlockState state) {
         if (vector3i.getY() == player.compensatedWorld.getDimension().minY() - 41) {
             return SOLID_SHAPE;
@@ -113,12 +123,35 @@ public class BedrockCollision {
             }
 
             // Workaround.... we can still ensure player won't be having weird y motion on bamboo using the VERTICAL_COLLISION input.
-            Box solidOffset = SOLID_SHAPE.get(0).offset(vector3i.getX(), vector3i.getY(), vector3i.getZ());
+            Box solidOffset = SOLID_SHAPE.getFirst().offset(vector3i.getX(), vector3i.getY(), vector3i.getZ());
 
             // If player claimed to have y collision and their feet/head does hit something then we can be sure it's correct.
             // Also, this bamboo should not collide with player horizontal collision, only vertical so we can handle it properly.
             boolean likelyYCollision = solidOffset.calculateMaxDistance(Axis.Y, player.boundingBox, player.velocity.y) != player.velocity.y;
             return likelyYCollision && solidOffset.intersects(box) ? SOLID_SHAPE : EMPTY_SHAPE;
+        }
+
+        if (state.is(Blocks.POINTED_DRIPSTONE)) {
+            // Like bamboo
+            if (!player.getInputData().contains(PlayerAuthInputData.VERTICAL_COLLISION) || box == null) {
+                return EMPTY_SHAPE;
+            }
+
+            List<Box> javaBoxes = state.getCollisionBoxes();
+            if (javaBoxes.isEmpty()) {
+                return EMPTY_SHAPE;
+            }
+
+            float minY = 1f, maxY = 0f;
+            for (Box b : javaBoxes) {
+                minY = Math.min(minY, b.minY);
+                maxY = Math.max(maxY, b.maxY);
+            }
+
+            List<Box> vertical = List.of(new Box(0, minY, 0, 1, maxY, 1));
+            Box verticalOffset = vertical.getFirst().offset(vector3i.getX(), vector3i.getY(), vector3i.getZ());
+            boolean likelyYCollision = verticalOffset.calculateMaxDistance(Axis.Y, player.boundingBox, player.velocity.y) != player.velocity.y;
+            return likelyYCollision && verticalOffset.intersects(box) ? vertical : EMPTY_SHAPE;
         }
 
         if (state.is(Blocks.END_PORTAL_FRAME)) {
@@ -132,7 +165,7 @@ public class BedrockCollision {
             }
         }
 
-        if (state.is(Blocks.ANVIL) || state.is(Blocks.DAMAGED_ANVIL) || state.is(Blocks.CHIPPED_ANVIL)) {
+        if (BlockMappings.get().getAnvilBlocks().contains(state.block())) {
             Direction direction = state.get(Properties.HORIZONTAL_FACING);
             if (direction.getAxis() == Axis.X) {
                 return ANVIL_X_SHAPE;
@@ -141,8 +174,8 @@ public class BedrockCollision {
             }
         }
 
-        if (state.is(Blocks.LANTERN) || state.is(Blocks.SOUL_LANTERN)) {
-            return LANTERN_SHAPE;
+        if (BlockMappings.get().getLanternBlocks().contains(state.block())) {
+            return Boolean.TRUE.equals(state.get(Properties.HANGING)) ? HANGING_LANTERN_SHAPE : LANTERN_SHAPE;
         }
 
         if (state.is(Blocks.ENDER_CHEST)) {
@@ -151,6 +184,14 @@ public class BedrockCollision {
 
         if (state.is(Blocks.SEA_PICKLE)) {
             return EMPTY_SHAPE;
+        }
+
+        if (state.is(Blocks.TURTLE_EGG)) {
+            return TURTLE_EGG_SHAPE;
+        }
+
+        if (state.is(Blocks.DRAGON_EGG)) {
+            return SOLID_SHAPE;
         }
 
         if (BlockMappings.get().getBedBlocks().contains(state.block())) {
@@ -165,7 +206,7 @@ public class BedrockCollision {
             return LECTERN_SHAPE;
         }
 
-        if (state.is(Blocks.CAULDRON) || state.is(Blocks.WATER_CAULDRON) || state.is(Blocks.LAVA_CAULDRON) || state.is(Blocks.POWDER_SNOW_CAULDRON)) {
+        if (BlockMappings.get().getCauldronBlocks().contains(state.block())) {
             return CAULDRON_SHAPE;
         }
 
@@ -178,42 +219,7 @@ public class BedrockCollision {
         }
 
         if (BlockMappings.get().getChestBlocks().contains(state.block())) {
-            final ChestType type = state.get(Properties.CHEST_TYPE);
-            Direction facing = state.get(Properties.HORIZONTAL_FACING);
-            if (type == ChestType.LEFT) {
-                facing = switch (facing) {
-                    case SOUTH -> Direction.WEST;
-                    case WEST -> Direction.NORTH;
-                    case EAST -> Direction.SOUTH;
-                    default -> Direction.EAST;
-                };
-            } else {
-                facing = switch (facing) {
-                    case SOUTH -> Direction.EAST;
-                    case WEST -> Direction.SOUTH;
-                    case EAST -> Direction.NORTH;
-                    default -> Direction.WEST;
-                };
-            }
-
-            if (type == ChestType.SINGLE) {
-                return SINGLE_CHEST_SHAPE;
-            } else {
-                switch (facing) {
-                    case SOUTH -> {
-                        return SOUTH_CHEST_SHAPE;
-                    }
-                    case WEST -> {
-                        return WEST_CHEST_SHAPE;
-                    }
-                    case EAST -> {
-                        return EAST_CHEST_SHAPE;
-                    }
-                    default -> {
-                        return NORTH_CHEST_SHAPE;
-                    }
-                }
-            }
+            return SINGLE_CHEST_SHAPE;
         }
 
         if (BlockMappings.get().getTrapDoorBlocks().contains(state.block())) {

--- a/common/src/main/java/ac/boar/anticheat/compensated/world/CompensatedWorldImpl.java
+++ b/common/src/main/java/ac/boar/anticheat/compensated/world/CompensatedWorldImpl.java
@@ -55,8 +55,11 @@ public class CompensatedWorldImpl extends CompensatedWorld {
             int x = iterator.getX(), y = iterator.getY(), z = iterator.getZ();
             if (this.isChunkLoaded(x, z)) {
                 BoarBlockState state = this.getBlockState(x, y, z, 0);
-                if (state.is(Blocks.BAMBOO) && new Box(x, y, z, x + 1, y + 1, z + 1).intersects(aABB)) {
+                if ((state.is(Blocks.BAMBOO) || state.is(Blocks.POINTED_DRIPSTONE)) && new Box(x, y, z, x + 1, y + 1, z + 1).intersects(aABB)) {
                     getPlayer().nearBamboo = true;
+                    if (state.is(Blocks.POINTED_DRIPSTONE)) {
+                        getPlayer().nearDripstone = true;
+                    }
                 }
 
                 builder.addAll(state.findCollision(this.getPlayer(), Vector3i.from(x, y, z), aABB, true));

--- a/common/src/main/java/ac/boar/anticheat/data/FluidState.java
+++ b/common/src/main/java/ac/boar/anticheat/data/FluidState.java
@@ -18,6 +18,10 @@ public record FluidState(Fluid fluid, float height, int level) {
     }
 
     public Vec3 getFlow(final BoarPlayer player, final Vector3i vector3i) {
+        if (player.compensatedWorld.getBlockState(vector3i, 0).is(Blocks.BUBBLE_COLUMN)) {
+            return new Vec3(0, 0, 0);
+        }
+
         Vec3 vec3 = new Vec3(0, 0, 0);
         int i = this.getEffectiveFlowDecay();
 

--- a/common/src/main/java/ac/boar/anticheat/data/block/AbstractBoarBlockState.java
+++ b/common/src/main/java/ac/boar/anticheat/data/block/AbstractBoarBlockState.java
@@ -179,6 +179,17 @@ public abstract class AbstractBoarBlockState implements BoarBlockState {
             return list;
         }
 
+        List<Box> connectionOverride = delegate.connectionCollisionOverride(player, pos);
+        if (connectionOverride != null) {
+            for (Box box : connectionOverride) {
+                Box offset = box.offset(pos.getX(), pos.getY(), pos.getZ());
+                if (!checkAAB || offset.intersects(playerAABB)) {
+                    list.add(offset);
+                }
+            }
+            return list;
+        }
+
         BoarBlockState reshaped = delegate.applyConnectionShape(player, this, pos);
         for (Box box : reshaped.getCollisionBoxes()) {
             Box offset = box.offset(pos.getX(), pos.getY(), pos.getZ());

--- a/common/src/main/java/ac/boar/anticheat/data/block/BoarBlockStateDelegate.java
+++ b/common/src/main/java/ac/boar/anticheat/data/block/BoarBlockStateDelegate.java
@@ -35,6 +35,13 @@ public interface BoarBlockStateDelegate {
 
     int getLayer();
 
+    // Bedrock shapes that cannot round-trip through a Java block state (thin bars, walls): built
+    // straight from the neighbours into local boxes. Returns null when the block has no override and
+    // the applyConnectionShape path should be used instead.
+    default List<Box> connectionCollisionOverride(BoarPlayer player, Vector3i pos) {
+        return null;
+    }
+
     // Returns a reshaped state with connection properties applied (fences, iron bars, chests, stairs).
     // Returns self when no reshape is needed.
     BoarBlockState applyConnectionShape(BoarPlayer player, BoarBlockState self, Vector3i pos);

--- a/common/src/main/java/ac/boar/anticheat/packets/input/PostAuthInputPackets.java
+++ b/common/src/main/java/ac/boar/anticheat/packets/input/PostAuthInputPackets.java
@@ -19,6 +19,7 @@ public class PostAuthInputPackets implements PacketListener {
             player.doingInventoryAction = false;
             player.hasDepthStrider = false;
             player.nearBamboo = false;
+            player.nearDripstone = false;
 
             player.getTeleportUtil().getAuthInputHistory().put(packet.getTick(), new TickData(packet, player.getFlagTracker().cloneFlags(), player.cloneAttributes(), player.dimensions));
 

--- a/common/src/main/java/ac/boar/anticheat/player/data/PlayerData.java
+++ b/common/src/main/java/ac/boar/anticheat/player/data/PlayerData.java
@@ -44,7 +44,7 @@ public class PlayerData {
             0.3F, AttributeOperation.MULTIPLY_TOTAL, 2, false);
 
     public final static float JUMP_HEIGHT = 0.42F;
-    public final static float STEP_HEIGHT = 0.6F;
+    public final static float STEP_HEIGHT = 0.5625F;
     public final static float GRAVITY = 0.08F;
 
     // Mappings related
@@ -157,6 +157,7 @@ public class PlayerData {
     public boolean soulSandBelow;
 
     public boolean nearBamboo;
+    public boolean nearDripstone;
 
     public boolean beingPushByLava;
 

--- a/common/src/main/java/ac/boar/anticheat/prediction/UncertainRunner.java
+++ b/common/src/main/java/ac/boar/anticheat/prediction/UncertainRunner.java
@@ -9,6 +9,7 @@ import ac.boar.anticheat.util.math.Box;
 import ac.boar.anticheat.util.math.Vec3;
 import lombok.RequiredArgsConstructor;
 import org.cloudburstmc.math.GenericMath;
+import org.cloudburstmc.protocol.bedrock.data.PlayerAuthInputData;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 
 import java.util.ArrayList;
@@ -178,6 +179,15 @@ public class UncertainRunner {
             if (offset <= 8.0E-4 && player.glideBoostTicks >= 0) {
                 extra = offset;
             }
+        }
+
+        boolean dripstoneHorizontalNotExceeded = actual.horizontalLengthSquared() <= predicted.horizontalLengthSquared() + 1.0E-6F;
+        boolean dripstoneHorizontalSaneDir = (MathUtil.sign(actual.x) == MathUtil.sign(predicted.x) || actual.x == 0)
+                && (MathUtil.sign(actual.z) == MathUtil.sign(predicted.z) || actual.z == 0);
+        if (player.nearDripstone && player.getInputData().contains(PlayerAuthInputData.VERTICAL_COLLISION)
+                && Math.abs(player.position.y - player.unvalidatedPosition.y) <= 0.3125F + player.getMaxOffset()
+                && dripstoneHorizontalNotExceeded && dripstoneHorizontalSaneDir) {
+            extra = offset;
         }
 
         return extra;

--- a/common/src/main/java/ac/boar/mappings/block/BlockMappings.java
+++ b/common/src/main/java/ac/boar/mappings/block/BlockMappings.java
@@ -35,6 +35,14 @@ public interface BlockMappings {
 
     List<Block> getButtonBlocks();
 
+    List<Block> getBarsBlocks();
+
+    List<Block> getLanternBlocks();
+
+    List<Block> getAnvilBlocks();
+
+    List<Block> getCauldronBlocks();
+
     Map<Item, Block> getItemToBlock();
 
     static BlockMappings get() {

--- a/common/src/main/java/ac/boar/mappings/block/Blocks.java
+++ b/common/src/main/java/ac/boar/mappings/block/Blocks.java
@@ -26,35 +26,33 @@ public final class Blocks {
     public static final Reference<Block> COBWEB = create("cobweb");
     public static final Reference<Block> CONDUIT = create("conduit");
     public static final Reference<Block> DAMAGED_ANVIL = create("damaged_anvil");
+    public static final Reference<Block> DRAGON_EGG = create("dragon_egg");
     public static final Reference<Block> END_PORTAL_FRAME = create("end_portal_frame");
     public static final Reference<Block> ENDER_CHEST =  create("ender_chest");
     public static final Reference<Block> FROSTED_ICE = create("frosted_ice");
     public static final Reference<Block> FURNACE = create("furnace");
     public static final Reference<Block> HONEY_BLOCK = create("honey_block");
     public static final Reference<Block> ICE = create("ice");
-    public static final Reference<Block> LANTERN = create("lantern");
     public static final Reference<Block> LAVA = create("lava");
-    public static final Reference<Block> LAVA_CAULDRON = create("lava_cauldron");
     public static final Reference<Block> LECTERN = create("lectern");
     public static final Reference<Block> LEVER = create("lever");
     public static final Reference<Block> NOTE_BLOCK = create("note_block");
     public static final Reference<Block> PACKED_ICE = create("packed_ice");
+    public static final Reference<Block> POINTED_DRIPSTONE = create("pointed_dripstone");
     public static final Reference<Block> POWDER_SNOW = create("powder_snow");
-    public static final Reference<Block> POWDER_SNOW_CAULDRON = create("powder_snow_cauldron");
     public static final Reference<Block> PUMPKIN = create("pumpkin");
     public static final Reference<Block> REDSTONE_ORE = create("redstone_ore");
     public static final Reference<Block> RESPAWN_ANCHOR = create("respawn_anchor");
     public static final Reference<Block> SCAFFOLDING = create("scaffolding");
     public static final Reference<Block> SEA_PICKLE = create("sea_pickle");
     public static final Reference<Block> SLIME_BLOCK = create("slime_block");
-    public static final Reference<Block> SOUL_LANTERN = create("soul_lantern");
     public static final Reference<Block> SOUL_SAND = create("soul_sand");
     public static final Reference<Block> SWEET_BERRY_BUSH = create("sweet_berry_bush");
     public static final Reference<Block> TNT = create("tnt");
+    public static final Reference<Block> TURTLE_EGG = create("turtle_egg");
     public static final Reference<Block> VAULT = create("vault");
     public static final Reference<Block> VOID_AIR = create("void_air");
     public static final Reference<Block> WATER = create("water");
-    public static final Reference<Block> WATER_CAULDRON = create("water_cauldron");
 
     private static Reference<Block> create(String key) {
         return POPULATOR.defer("minecraft:" + key);

--- a/common/src/main/java/ac/boar/mappings/block/Properties.java
+++ b/common/src/main/java/ac/boar/mappings/block/Properties.java
@@ -10,6 +10,7 @@ public final class Properties {
     public static final Property<String> DOOR_HINGE = create("door_hinge");
     public static final Property<Boolean> DRAG = create("drag");
     public static final Property<String> HALF = create("half");
+    public static final Property<Boolean> HANGING = create("hanging");
     public static final Property<Boolean> HAS_BOOK = create("has_book");
     public static final Property<Direction> HORIZONTAL_FACING = create("horizontal_facing");
     public static final Property<Integer> LEVEL = create("level");

--- a/geyser/src/main/java/ac/boar/geyser/anticheat/data/block/GeyserBoarBlockStateDelegate.java
+++ b/geyser/src/main/java/ac/boar/geyser/anticheat/data/block/GeyserBoarBlockStateDelegate.java
@@ -3,6 +3,7 @@ package ac.boar.geyser.anticheat.data.block;
 import ac.boar.anticheat.data.block.AbstractBoarBlockState;
 import ac.boar.anticheat.data.block.BoarBlockState;
 import ac.boar.anticheat.data.block.BoarBlockStateDelegate;
+import ac.boar.anticheat.collision.BedrockCollision;
 import ac.boar.anticheat.player.BoarPlayer;
 import ac.boar.anticheat.util.math.Box;
 import ac.boar.geyser.anticheat.util.block.GeyserBlockUtil;
@@ -32,7 +33,6 @@ import org.geysermc.geyser.util.BlockUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
 @RequiredArgsConstructor
 @Getter
@@ -90,6 +90,17 @@ public class GeyserBoarBlockStateDelegate implements BoarBlockStateDelegate {
     }
 
     @Override
+    public List<Box> connectionCollisionOverride(BoarPlayer player, Vector3i pos) {
+        if (BlockMappings.get().getBarsBlocks().contains(this.block())) {
+            return GeyserBlockUtil.computeBarsShape(player, pos);
+        }
+        if (BlockMappings.get().getWallBlocks().contains(this.block())) {
+            return GeyserBlockUtil.computeWallShape(player, pos);
+        }
+        return null;
+    }
+
+    @Override
     public List<Box> getCollisionBoxes() {
         // Geyser returns null for blocks it has no collision data for (unmapped/unknown block IDs).
         // Treat as a non-collidable block (like air) instead of NPEing the prediction tick — that
@@ -123,7 +134,7 @@ public class GeyserBoarBlockStateDelegate implements BoarBlockStateDelegate {
         BlockState newState;
         if (BlockMappings.get().getFenceBlocks().contains(this.block())) {
             newState = GeyserBlockUtil.findFenceBlockState(player, this.state, pos);
-        } else if (this.state.is(Blocks.IRON_BARS) || this.state.toString().toLowerCase(Locale.ROOT).contains("glass_pane")) {
+        } else if (BlockMappings.get().getBarsBlocks().contains(this.block())) {
             newState = GeyserBlockUtil.findIronBarsBlockState(player, this.state, pos);
         } else if (this.state.is(Blocks.CHEST) || this.state.is(Blocks.TRAPPED_CHEST)) {
             newState = GeyserBlockUtil.findChestState(player, this.state, pos);

--- a/geyser/src/main/java/ac/boar/geyser/anticheat/util/block/GeyserBlockUtil.java
+++ b/geyser/src/main/java/ac/boar/geyser/anticheat/util/block/GeyserBlockUtil.java
@@ -3,6 +3,7 @@ package ac.boar.geyser.anticheat.util.block;
 import ac.boar.anticheat.data.block.BoarBlockState;
 import ac.boar.anticheat.player.BoarPlayer;
 import ac.boar.anticheat.util.geyser.BlockEntityInfo;
+import ac.boar.anticheat.util.math.Box;
 import ac.boar.geyser.anticheat.data.block.GeyserBoarBlockStateDelegate;
 import ac.boar.geyser.anticheat.util.math.GeyserDirectionUtil;
 import ac.boar.mappings.block.BlockMappings;
@@ -13,12 +14,13 @@ import org.geysermc.geyser.level.block.type.BlockState;
 import org.geysermc.geyser.level.physics.Direction;
 import org.geysermc.geyser.registry.BlockRegistries;
 
-import java.util.Locale;
+import java.util.List;
 import java.util.Objects;
 
 import static org.geysermc.geyser.level.block.property.Properties.CHEST_TYPE;
 import static org.geysermc.geyser.level.block.property.Properties.HALF;
 import static org.geysermc.geyser.level.block.property.Properties.HORIZONTAL_FACING;
+import static org.geysermc.geyser.level.block.property.Properties.UP;
 
 public final class GeyserBlockUtil {
 
@@ -91,6 +93,56 @@ public final class GeyserBlockUtil {
         return BlockState.of(BlockRegistries.JAVA_BLOCK_STATE_IDENTIFIER_TO_ID.getOrDefault(identifier, state.javaId()));
     }
 
+    public static List<Box> computeBarsShape(BoarPlayer player, Vector3i position) {
+        BoarBlockState north = player.compensatedWorld.getBlockState(position.north(), 0);
+        BoarBlockState south = player.compensatedWorld.getBlockState(position.south(), 0);
+        BoarBlockState west = player.compensatedWorld.getBlockState(position.west(), 0);
+        BoarBlockState east = player.compensatedWorld.getBlockState(position.east(), 0);
+
+        boolean n = attachsTo(north, north.isFaceSturdy(player));
+        boolean e = attachsTo(east, east.isFaceSturdy(player));
+        boolean s = attachsTo(south, south.isFaceSturdy(player));
+        boolean w = attachsTo(west, west.isFaceSturdy(player));
+
+        return ac.boar.anticheat.collision.BedrockCollision.buildThinBarsShape(n, e, s, w);
+    }
+
+    public static List<Box> computeWallShape(BoarPlayer player, Vector3i position) {
+        BoarBlockState north = player.compensatedWorld.getBlockState(position.north(), 0);
+        BoarBlockState east = player.compensatedWorld.getBlockState(position.east(), 0);
+        BoarBlockState south = player.compensatedWorld.getBlockState(position.south(), 0);
+        BoarBlockState west = player.compensatedWorld.getBlockState(position.west(), 0);
+        BoarBlockState above = player.compensatedWorld.getBlockState(position.up(), 0);
+
+        boolean n = wallConnectsTo(north, north.isFaceSturdy(player), Direction.SOUTH);
+        boolean e = wallConnectsTo(east, east.isFaceSturdy(player), Direction.WEST);
+        boolean s = wallConnectsTo(south, south.isFaceSturdy(player), Direction.NORTH);
+        boolean w = wallConnectsTo(west, west.isFaceSturdy(player), Direction.EAST);
+
+        BlockState aboveRaw = GeyserBoarBlockStateDelegate.unwrap(above).getState();
+        boolean aboveForcesPost = above.isFaceSturdy(player)
+                || (BlockMappings.get().getWallBlocks().contains(above.block()) && Boolean.TRUE.equals(aboveRaw.getValue(UP)));
+
+        boolean straight = (n && s && !e && !w) || (e && w && !n && !s);
+        boolean up = aboveForcesPost || !straight;
+
+        float minX = 1f, minZ = 1f, maxX = 0f, maxZ = 0f;
+        if (up) { minX = Math.min(minX, 0.25f); maxX = Math.max(maxX, 0.75f); minZ = Math.min(minZ, 0.25f); maxZ = Math.max(maxZ, 0.75f); }
+        if (n)  { minX = Math.min(minX, 0.3125f); maxX = Math.max(maxX, 0.6875f); minZ = 0f; }
+        if (s)  { minX = Math.min(minX, 0.3125f); maxX = Math.max(maxX, 0.6875f); maxZ = 1f; }
+        if (w)  { minZ = Math.min(minZ, 0.3125f); maxZ = Math.max(maxZ, 0.6875f); minX = 0f; }
+        if (e)  { minZ = Math.min(minZ, 0.3125f); maxZ = Math.max(maxZ, 0.6875f); maxX = 1f; }
+
+        return java.util.List.of(new ac.boar.anticheat.util.math.Box(minX, 0f, minZ, maxX, 1.5f, maxZ));
+    }
+
+    private static boolean wallConnectsTo(BoarBlockState neighbour, boolean faceSturdy, Direction direction) {
+        boolean wall = BlockMappings.get().getWallBlocks().contains(neighbour.block());
+        boolean barsOrPane = BlockMappings.get().getBarsBlocks().contains(neighbour.block());
+        return wall || barsOrPane || connectsToDirection(neighbour, direction)
+                || (!isExceptionForConnection(neighbour) && faceSturdy);
+    }
+
     public static String getStairShape(BoarPlayer player, BlockState state, Vector3i pos) {
         Direction direction = state.getValue(HORIZONTAL_FACING);
         BoarBlockState ahead = player.compensatedWorld.getBlockState(pos.add(direction.getUnitVector()), 0);
@@ -138,8 +190,8 @@ public final class GeyserBlockUtil {
 
     private static boolean attachsTo(BoarBlockState neighbour, boolean faceSturdy) {
         boolean walls = BlockMappings.get().getWallBlocks().contains(neighbour.block());
-        BlockState raw = GeyserBoarBlockStateDelegate.unwrap(neighbour).getState();
-        return !isExceptionForConnection(neighbour) && faceSturdy || raw.is(Blocks.IRON_BARS) || raw.toString().toLowerCase(Locale.ROOT).contains("glass_pane") || walls;
+        boolean bars = BlockMappings.get().getBarsBlocks().contains(neighbour.block());
+        return !isExceptionForConnection(neighbour) && faceSturdy || bars || walls;
     }
 
     private static boolean isSameFence(BoarBlockState neighbour, BlockState main) {

--- a/geyser/src/main/java/ac/boar/geyser/mappings/block/GeyserBlockMappings.java
+++ b/geyser/src/main/java/ac/boar/geyser/mappings/block/GeyserBlockMappings.java
@@ -39,6 +39,10 @@ public final class GeyserBlockMappings implements BlockMappings {
     private final List<Block> candleBlocks = new ArrayList<>();
     private final List<Block> signBlocks = new ArrayList<>();
     private final List<Block> buttonBlocks = new ArrayList<>();
+    private final List<Block> barsBlocks = new ArrayList<>();
+    private final List<Block> lanternBlocks = new ArrayList<>();
+    private final List<Block> anvilBlocks = new ArrayList<>();
+    private final List<Block> cauldronBlocks = new ArrayList<>();
 
     private final Map<String, Block> keyToBlock = new HashMap<>();
 
@@ -67,6 +71,22 @@ public final class GeyserBlockMappings implements BlockMappings {
                         mappings.candleBlocks.add(new GeyserBlock(block));
                     } else if (lowercaseName.endsWith("_sign")) {
                         mappings.signBlocks.add(new GeyserBlock(block));
+                    }
+
+                    if (lowercaseName.endsWith("_bars") || lowercaseName.endsWith("_pane")) {
+                        mappings.barsBlocks.add(new GeyserBlock(block));
+                    }
+
+                    if (lowercaseName.equals("lantern") || lowercaseName.endsWith("_lantern")) {
+                        mappings.lanternBlocks.add(new GeyserBlock(block));
+                    }
+
+                    if (lowercaseName.equals("anvil") || lowercaseName.endsWith("_anvil")) {
+                        mappings.anvilBlocks.add(new GeyserBlock(block));
+                    }
+
+                    if (lowercaseName.equals("cauldron") || lowercaseName.endsWith("_cauldron")) {
+                        mappings.cauldronBlocks.add(new GeyserBlock(block));
                     }
 
                     if (block instanceof BedBlock) {
@@ -187,6 +207,26 @@ public final class GeyserBlockMappings implements BlockMappings {
     @Override
     public List<Block> getButtonBlocks() {
         return Collections.unmodifiableList(buttonBlocks);
+    }
+
+    @Override
+    public List<Block> getBarsBlocks() {
+        return Collections.unmodifiableList(barsBlocks);
+    }
+
+    @Override
+    public List<Block> getLanternBlocks() {
+        return Collections.unmodifiableList(lanternBlocks);
+    }
+
+    @Override
+    public List<Block> getAnvilBlocks() {
+        return Collections.unmodifiableList(anvilBlocks);
+    }
+
+    @Override
+    public List<Block> getCauldronBlocks() {
+        return Collections.unmodifiableList(cauldronBlocks);
     }
 
     @Override

--- a/geyser/src/main/java/ac/boar/geyser/mappings/block/GeyserPropertyProvider.java
+++ b/geyser/src/main/java/ac/boar/geyser/mappings/block/GeyserPropertyProvider.java
@@ -25,6 +25,7 @@ public class GeyserPropertyProvider implements PropertyProvider {
             case "door_hinge" -> new GeyserProperty(Properties.DOOR_HINGE);
             case "drag" -> new GeyserProperty(Properties.DRAG);
             case "half" -> new GeyserProperty(Properties.HALF);
+            case "hanging" -> new GeyserProperty(Properties.HANGING);
             case "has_book" -> new GeyserProperty(Properties.HAS_BOOK);
             case "horizontal_facing" -> enumProperty(
                     Properties.HORIZONTAL_FACING,


### PR DESCRIPTION
Iron bars, glass panes, and walls lose geometry when reshaped through a Java
block state. Added a `connectionCollisionOverride` delegate hook that builds
the boxes straight from the neighbours instead.

Also aligned with Bedrock: pointed dripstone (vertical-collision only, like
bamboo), hanging lanterns, turtle/dragon eggs, double chests, and skipped
water flow inside bubble columns.