### PR TITLE
added configurable messages and "alerts-enabled-by-default" option

### DIFF
--- a/common/src/main/java/ac/boar/anticheat/alert/AlertViolationListener.java
+++ b/common/src/main/java/ac/boar/anticheat/alert/AlertViolationListener.java
@@ -10,15 +10,15 @@ public final class AlertViolationListener implements ViolationListener {
     public void onViolation(Violation violation) {
         final Check check = violation.check();
 
-        final StringBuilder builder = new StringBuilder("§3" + violation.player().getSession().name() + "§7 failed§6 " + check.name());
-        if (!check.type().isBlank()) {
-            builder.append(" (").append(check.type()).append(")");
-        }
-        if (check.experimental()) {
-            builder.append(" §a(Experimental)");
-        }
-        builder.append(" §7x").append(violation.vl()).append(" ").append(violation.verbose());
+        String message = Boar.getConfig().messages().alertFormat()
+                .replace("{player}", violation.player().getSession().name())
+                .replace("{check}", check.name())
+                .replace("{type}", check.type())
+                .replace("{experimental}", check.experimental() ? " §a(Experimental)" : "")
+                .replace("{level}", String.valueOf(violation.vl()))
+                .replace("{reason}", violation.verbose())
+                .replace("&", "§");
 
-        Boar.getInstance().getAlertManager().alert(builder.toString());
+        Boar.getInstance().getAlertManager().alert(message);
     }
 }

--- a/common/src/main/java/ac/boar/anticheat/check/impl/badpackets/BadPacketA.java
+++ b/common/src/main/java/ac/boar/anticheat/check/impl/badpackets/BadPacketA.java
@@ -1,6 +1,7 @@
 package ac.boar.anticheat.check.impl.badpackets;
 
 import ac.boar.api.anticheat.annotations.CheckInfo;
+import ac.boar.anticheat.Boar;
 import ac.boar.anticheat.check.api.BaseCheck;
 import ac.boar.anticheat.check.api.impl.PacketCheck;
 import ac.boar.anticheat.player.BoarPlayer;
@@ -19,7 +20,7 @@ public class BadPacketA extends BaseCheck implements PacketCheck {
         if (event.getPacket() instanceof PlayerAuthInputPacket packet) {
             if (!MathUtil.isValid(packet.getPosition()) || !MathUtil.isValid(packet.getRotation()) || !MathUtil.isValid(packet.getDelta())) {
                 fail("pos=" + packet.getPosition() + ", rot=" + packet.getRotation() + ", delta=" + packet.getDelta());
-                player.kick("Invalid auth input packet!");
+                player.kick(Boar.getConfig().messages().kickInvalidAuth());
             }
         }
     }

--- a/common/src/main/java/ac/boar/anticheat/check/impl/badpackets/BadPacketB.java
+++ b/common/src/main/java/ac/boar/anticheat/check/impl/badpackets/BadPacketB.java
@@ -1,6 +1,7 @@
 package ac.boar.anticheat.check.impl.badpackets;
 
 import ac.boar.anticheat.check.api.BaseCheck;
+import ac.boar.anticheat.Boar;
 import ac.boar.anticheat.check.api.impl.PacketCheck;
 import ac.boar.anticheat.player.BoarPlayer;
 import ac.boar.anticheat.util.MathUtil;
@@ -31,6 +32,6 @@ public class BadPacketB extends BaseCheck implements PacketCheck {
         }
 
         // Should be safe to kick?
-        player.kick("Invalid auth input packet!");
+        player.kick(Boar.getConfig().messages().kickInvalidAuth());
     }
 }

--- a/common/src/main/java/ac/boar/anticheat/config/Config.java
+++ b/common/src/main/java/ac/boar/anticheat/config/Config.java
@@ -49,6 +49,9 @@ public final class Config {
     @JsonProperty("alerts-enabled-by-default")
     @JsonSetter(nulls = Nulls.SKIP)
     private boolean alertsEnabledByDefault = false;
+    @JsonProperty("messages")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private Messages messages = new Messages();
     // Cached copy of the prefix with & converted to §. Lives on the config instance,
     // so reloading the config (which creates a new instance) resets it.
     @JsonIgnore
@@ -99,11 +102,51 @@ public final class Config {
         return alertsEnabledByDefault;
     }
 
+    public Messages messages() {
+        return messages;
+    }
+
     public String formattedPrefix() {
         if (formattedPrefix == null) {
             formattedPrefix = prefix.replace('&', '§');
         }
 
         return formattedPrefix;
+    }
+
+    @ToString
+    @Setter
+    public static class Messages {
+        @JsonProperty("kick-invalid-auth")
+        @JsonSetter(nulls = Nulls.SKIP)
+        private String kickInvalidAuth = "Invalid auth input packet!";
+
+        @JsonProperty("kick-impossible-tick")
+        @JsonSetter(nulls = Nulls.SKIP)
+        private String kickImpossibleTick = "Impossible tick id={tick}";
+
+        @JsonProperty("kick-timeout")
+        @JsonSetter(nulls = Nulls.SKIP)
+        private String kickTimeout = "Timed out!";
+
+        @JsonProperty("alert-format")
+        @JsonSetter(nulls = Nulls.SKIP)
+        private String alertFormat = "&3{player}&7 failed&6 {check} ({type}){experimental} &7x{level} {reason}";
+
+        public String kickInvalidAuth() {
+            return kickInvalidAuth;
+        }
+
+        public String kickImpossibleTick() {
+            return kickImpossibleTick;
+        }
+
+        public String kickTimeout() {
+            return kickTimeout;
+        }
+
+        public String alertFormat() {
+            return alertFormat;
+        }
     }
 }

--- a/common/src/main/java/ac/boar/anticheat/config/Config.java
+++ b/common/src/main/java/ac/boar/anticheat/config/Config.java
@@ -46,6 +46,9 @@ public final class Config {
     @JsonProperty("prefix")
     @JsonSetter(nulls = Nulls.SKIP)
     private String prefix = "&3Boar &7>&r ";
+    @JsonProperty("alerts-enabled-by-default")
+    @JsonSetter(nulls = Nulls.SKIP)
+    private boolean alertsEnabledByDefault = false;
     // Cached copy of the prefix with & converted to §. Lives on the config instance,
     // so reloading the config (which creates a new instance) resets it.
     @JsonIgnore
@@ -90,6 +93,10 @@ public final class Config {
 
     public String prefix() {
         return prefix;
+    }
+
+    public boolean alertsEnabledByDefault() {
+        return alertsEnabledByDefault;
     }
 
     public String formattedPrefix() {

--- a/common/src/main/java/ac/boar/anticheat/config/ConfigLoader.java
+++ b/common/src/main/java/ac/boar/anticheat/config/ConfigLoader.java
@@ -80,6 +80,7 @@ public class ConfigLoader {
                                 .replace("\r", "\\r")
                                 .replace("\n", "\\n");
                         s = s.replace("prefix: \"&3Boar &7>&r \"", "prefix: \"" + prefix + "\"");
+                        s = s.replace("alerts-enabled-by-default: false", "alerts-enabled-by-default: " + config.alertsEnabledByDefault());
                     }
 
                     writer.write(s.toCharArray());

--- a/common/src/main/java/ac/boar/anticheat/packets/input/AuthInputPackets.java
+++ b/common/src/main/java/ac/boar/anticheat/packets/input/AuthInputPackets.java
@@ -40,7 +40,7 @@ public class AuthInputPackets extends TeleportHandler implements PacketListener 
         final long claimedTick = packet.getTick();
 
         if (claimedTick < 0) { // Impossible, no way this can happen.
-            player.kick("Impossible tick id=" + claimedTick);
+            player.kick(Boar.getConfig().messages().kickImpossibleTick().replace("{tick}", String.valueOf(claimedTick)));
             return;
         }
 

--- a/common/src/main/java/ac/boar/anticheat/player/BoarPlayer.java
+++ b/common/src/main/java/ac/boar/anticheat/player/BoarPlayer.java
@@ -125,7 +125,7 @@ public final class BoarPlayer extends PlayerData {
         }
 
         if (System.currentTimeMillis() - this.getLatencyUtil().prevAcceptedTime > Boar.getConfig().maxLatencyWait()) {
-            kick("Timed out!");
+            kick(Boar.getConfig().messages().kickTimeout());
         }
     }
 

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -49,3 +49,10 @@ max-balance-advantage: 8500
 
 # Should debug mode be enabled or not?
 debug-mode: false
+
+# Messages sent to players/admins
+messages:
+  kick-invalid-auth: "Invalid auth input packet!"
+  kick-impossible-tick: "Impossible tick id={tick}"
+  kick-timeout: "Timed out!"
+  alert-format: "&3{player}&7 failed&6 {check} ({type}){experimental} &7x{level} {reason}"

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -3,6 +3,9 @@
 # This prefix is used in all Boar messages.
 prefix: "&3Boar &7>&r "
 
+# If true, players who have the boar.alert permission will automatically receive alerts.
+alerts-enabled-by-default: false
+
 # How many ticks of history are contained in the client's rolling window for use when receiving corrections.
 # At 20 ticks per second a history size of 40 means that a correction could still be processed with rewind with
 # two seconds of two-way latency

--- a/geyser/src/main/java/ac/boar/geyser/GeyserBoar.java
+++ b/geyser/src/main/java/ac/boar/geyser/GeyserBoar.java
@@ -51,6 +51,10 @@ public class GeyserBoar implements Extension {
 
         // System.out.println("Adding name " + event.connection().bedrockUsername() + " " + session);
         nameToSessions.put(event.connection().bedrockUsername(), session);
+
+        if (Boar.getConfig().alertsEnabledByDefault() && session.hasPermission("boar.alert")) {
+            Boar.getInstance().getAlertManager().addAlert(new GeyserMessageRecipient(session));
+        }
     }
 
     @Subscribe


### PR DESCRIPTION
an optional feature has been added to the config: alerts are enabled by default. admins no longer need to remember to type `/boar alert` every time