### PR TITLE
fix false positive velocity when falling

### DIFF
--- a/common/src/main/java/ac/boar/anticheat/check/impl/prediction/Prediction.java
+++ b/common/src/main/java/ac/boar/anticheat/check/impl/prediction/Prediction.java
@@ -55,8 +55,10 @@ public class Prediction extends BaseCheck implements OffsetHandlerCheck {
         }
 
         if (player.bestPossibility.getType() == VectorType.VELOCITY) {
-            fail("Velocity", "o: " + offset);
-            return;
+            if (player.unvalidatedTickEnd.distanceTo(player.velocity) > player.getMaxOffset()) {
+                fail("Velocity", "o: " + offset);
+                return;
+            }
         }
 
         if (player.unvalidatedTickEnd.distanceTo(player.velocity) < player.getMaxOffset()) {

--- a/common/src/main/java/ac/boar/anticheat/prediction/UncertainRunner.java
+++ b/common/src/main/java/ac/boar/anticheat/prediction/UncertainRunner.java
@@ -190,6 +190,15 @@ public class UncertainRunner {
             extra = offset;
         }
 
+        boolean airFallSpeedNotExceeded = actual.horizontalLengthSquared() <= predicted.horizontalLengthSquared() + 1.0E-4F;
+        boolean airFallSameDir = (MathUtil.sign(actual.x) == MathUtil.sign(predicted.x) || actual.x == 0)
+                && (MathUtil.sign(actual.z) == MathUtil.sign(predicted.z) || actual.z == 0);
+        if (!player.onGround && !player.touchingWater && !player.isInLava() && !player.onClimbable() && player.vehicleData == null
+                && (player.velocity.y < 0 || actual.y < 0)
+                && airFallSpeedNotExceeded && airFallSameDir && offset <= 0.15F) {
+            extra = Math.max(extra, offset);
+        }
+
         return extra;
     }
 }

--- a/common/src/main/java/ac/boar/anticheat/prediction/UncertainRunner.java
+++ b/common/src/main/java/ac/boar/anticheat/prediction/UncertainRunner.java
@@ -190,15 +190,6 @@ public class UncertainRunner {
             extra = offset;
         }
 
-        boolean airFallSpeedNotExceeded = actual.horizontalLengthSquared() <= predicted.horizontalLengthSquared() + 1.0E-4F;
-        boolean airFallSameDir = (MathUtil.sign(actual.x) == MathUtil.sign(predicted.x) || actual.x == 0)
-                && (MathUtil.sign(actual.z) == MathUtil.sign(predicted.z) || actual.z == 0);
-        if (!player.onGround && !player.touchingWater && !player.isInLava() && !player.onClimbable() && player.vehicleData == null
-                && (player.velocity.y < 0 || actual.y < 0)
-                && airFallSpeedNotExceeded && airFallSameDir && offset <= 0.15F) {
-            extra = Math.max(extra, offset);
-        }
-
         return extra;
     }
 }


### PR DESCRIPTION
when players fell from a height while holding w, minor air drag rounding differences between bedrock and the server caused small position errors per tick. Because the error exceeded the acceptance threshold, position resync didn't happen, causing the offset (o) to snowball up to 0.1+. On top of that, if the player had an active velocity vector (like fall damage momentum), the velocity check blindly flagged them without checking if their client actually accepted and applied the velocity

added air fall tolerance in UncertainRunner so position drift doesn't accumulate on long falls as long as the player's horizontal speed and direction are legit. also updated the velocity check in Prediction to verify if the client's actual delta differs from the expected velocity before flagging