### PR TITLE
Fix: preserve config values when updating old configs

### DIFF
--- a/common/src/main/java/ac/boar/anticheat/config/Config.java
+++ b/common/src/main/java/ac/boar/anticheat/config/Config.java
@@ -21,7 +21,7 @@ public final class Config {
     private int rewindHistory = 20;
     @JsonProperty("player-position-acceptance-threshold")
     @JsonSetter(nulls = Nulls.SKIP)
-    private float acceptanceThreshold = 1.0E-4F;
+    private float acceptanceThreshold = 1.0E-3F;
     @JsonProperty("max-tolerance-compensated-reach")
     @JsonSetter(nulls = Nulls.SKIP)
     private float toleranceReach = 3.005F;

--- a/common/src/main/java/ac/boar/anticheat/config/Config.java
+++ b/common/src/main/java/ac/boar/anticheat/config/Config.java
@@ -39,7 +39,7 @@ public final class Config {
     private long maxLatencyWait = 15000L;
     @JsonProperty("max-balance-advantage")
     @JsonSetter(nulls = Nulls.SKIP)
-    private long maxBalanceAdvantage = 2000L;
+    private long maxBalanceAdvantage = 8500L;
     @JsonProperty("debug-mode")
     @JsonSetter(nulls = Nulls.SKIP)
     private boolean debugMode;

--- a/common/src/main/java/ac/boar/anticheat/config/ConfigLoader.java
+++ b/common/src/main/java/ac/boar/anticheat/config/ConfigLoader.java
@@ -2,7 +2,9 @@ package ac.boar.anticheat.config;
 
 import ac.boar.anticheat.BoarPlatform;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import java.io.File;
@@ -13,8 +15,8 @@ import java.net.URISyntaxException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 
 // Credit to https://github.com/onebeastchris/MagicMenu
 public class ConfigLoader {
@@ -51,40 +53,41 @@ public class ConfigLoader {
 
     public static void save(BoarPlatform platform, Class<?> extensionClass, Config config) {
         File configFile = platform.dataFolder().resolve("config.yml").toFile();
-        // Well in case the old config file the server have is outdated.
+        // Add missing options if the config is outdated.
         writeConfigFile(configFile, extensionClass, platform, config);
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     private static boolean writeConfigFile(File configFile, Class<?> extensionClass, BoarPlatform platform, Config config) {
-        try (FileWriter writer = new FileWriter(configFile)) {
-            try (FileSystem fileSystem = FileSystems.newFileSystem(new File(extensionClass.getProtectionDomain().getCodeSource().getLocation().toURI()).toPath(), Collections.emptyMap())) {
-                try (InputStream input = Files.newInputStream(fileSystem.getPath("config.yml"))) {
-                    byte[] bytes = new byte[input.available()];
-                    input.read(bytes);
-
-                    String s = new String(bytes);
-                    // not really cool code ;(, and a bit hacky but ok....
-                    if (config != null) {
-                        s = s.replace("player-rewind-history-size-ticks: 20", "player-rewind-history-size-ticks: " + config.rewindHistory());
-                        s = s.replace("player-position-acceptance-threshold: 1.0E-4", "player-position-acceptance-threshold: " + config.acceptanceThreshold());
-                        s = s.replace("max-tolerance-compensated-reach: 3.005", "max-tolerance-compensated-reach: " + config.toleranceReach());
-                        s = s.replace("disabled-checks: []", "disabled-checks: " + Arrays.toString(config.disabledChecks().toArray(new String[0])));
-                        s = s.replace("ignore-ghost-block: false", "ignore-ghost-block: " + config.ignoreGhostBlock());
-                        s = s.replace("differ-till-alert: 0.0", "differ-till-alert: " + config.alertThreshold());
-                        s = s.replace("debug-mode: false", "debug-mode: " + config.debugMode());
-                        s = s.replace("max-latency-wait: 15000", "max-latency-wait: " + config.maxLatencyWait());
-                        String prefix = config.prefix()
-                                .replace("\\", "\\\\")
-                                .replace("\"", "\\\"")
-                                .replace("\r", "\\r")
-                                .replace("\n", "\\n");
-                        s = s.replace("prefix: \"&3Boar &7>&r \"", "prefix: \"" + prefix + "\"");
-                    }
-
-                    writer.write(s.toCharArray());
-                    writer.flush();
+        try {
+            String s;
+            if (config != null && configFile.exists()) {
+                ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+                JsonNode currentNode = mapper.readTree(configFile);
+                if (!(currentNode instanceof ObjectNode current)) {
+                    throw new IOException("Config root must be a mapping");
                 }
+                ObjectNode defaults = mapper.valueToTree(config);
+                boolean changed = false;
+                Iterator<String> fields = defaults.fieldNames();
+                while (fields.hasNext()) {
+                    String field = fields.next();
+                    if (!current.has(field)) {
+                        current.set(field, defaults.get(field)); changed = true;}}
+                if (!changed) {return true;}
+                s = mapper.writeValueAsString(current);
+            } else {
+                try (FileSystem fileSystem = FileSystems.newFileSystem(new File(extensionClass.getProtectionDomain().getCodeSource().getLocation().toURI()).toPath(), Collections.emptyMap())) {
+                    try (InputStream input = Files.newInputStream(fileSystem.getPath("config.yml"))) {
+                        byte[] bytes = new byte[input.available()];
+                        input.read(bytes);
+                        s = new String(bytes);
+                    }
+                }
+            }
+            try (FileWriter writer = new FileWriter(configFile)) {
+                writer.write(s.toCharArray());
+                writer.flush();
             }
         } catch (IOException | URISyntaxException e) {
             platform.logger().error("Failed to create config", e);

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -12,7 +12,7 @@ player-rewind-history-size-ticks: 20
 # This is the tolerance of discrepancies between the Client and Server Player position. This helps prevent sending corrections too frequently
 # NOTE: Again, Boar can handle small offset just fine and does account for lag, however keep in mind that Boar can't handle (that well)
 # any offset smaller than 5.0E-5
-player-position-acceptance-threshold: 1.0E-4
+player-position-acceptance-threshold: 1.0E-3
 
 # This is the max reach that Boar going to tolerance before flagging, it does account for lag so no worry :)
 max-tolerance-compensated-reach: 3.005


### PR DESCRIPTION
boar rebuilt the whole config.yml from the bundled template on shutdown. this could restore old in-memory values and reset options if the user didn't execute /boar reload

config saving now only adds options missing from an old config. existing values and unknown keys are kept, and an up-to-date config is not written again

small fix: the in-code max-balance-advantage default now also matches the bundled value

fixes #88